### PR TITLE
Add CDS Views for Goal Service

### DIFF
--- a/src/zc_goal_basic.ddls.asddls
+++ b/src/zc_goal_basic.ddls.asddls
@@ -1,0 +1,30 @@
+@AbapCatalog.sqlViewName: 'ZCGOALBASIC'
+@AbapCatalog.compiler.compareFilter: true
+@AbapCatalog.preserveKey: true
+@AccessControl.authorizationCheck: #CHECK
+@EndUserText.label: 'Goal Basic Consumption View'
+@Metadata.allowExtensions: true
+@Search.searchable: true
+
+define view ZC_GOAL_BASIC
+  as select from ZI_GOAL_BASIC
+{
+      @ObjectModel.text.element: ['GoalTitle']
+  key GoalId,
+      @Search.defaultSearchElement: true
+      Username,
+      @Search.defaultSearchElement: true
+      @Search.fuzzinessThreshold: 0.7
+      GoalTitle,
+      @Search.defaultSearchElement: true
+      @Search.fuzzinessThreshold: 0.7
+      GoalDescription,
+      CreatedOn,
+      
+      /* Administrative Data */
+      CreatedBy,
+      CreatedAt,
+      ChangedBy,
+      ChangedAt,
+      LocalLastChangedAt
+}

--- a/src/zc_goal_basic.ddls.xml
+++ b/src/zc_goal_basic.ddls.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DDLS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DDLS>
+    <DDLNAME>ZC_GOAL_BASIC</DDLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <DDTEXT>Goal Basic Consumption View</DDTEXT>
+    <SOURCE_TYPE>V</SOURCE_TYPE>
+   </DDLS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zc_goal_basic.ddlx.asddlxs
+++ b/src/zc_goal_basic.ddlx.asddlxs
@@ -1,0 +1,49 @@
+@Metadata.layer: #CORE
+@UI: {
+  headerInfo: {
+    typeName: 'Goal',
+    typeNamePlural: 'Goals',
+    title: {
+      type: #STANDARD,
+      value: 'GoalTitle'
+    }
+  }
+}
+annotate view ZC_GOAL_BASIC with
+{
+  @UI.facet: [ { id:              'Goal',
+                 purpose:          #STANDARD,
+                 type:             #IDENTIFICATION_REFERENCE,
+                 label:            'Goal',
+                 position:         10 } ]
+
+  @UI: {
+    lineItem:       [ { position: 10 } ],
+    identification: [ { position: 10 } ]
+  }
+  GoalId;
+
+  @UI: {
+    lineItem:       [ { position: 20 } ],
+    identification: [ { position: 20 } ]
+  }
+  Username;
+
+  @UI: {
+    lineItem:       [ { position: 30 } ],
+    identification: [ { position: 30 } ]
+  }
+  GoalTitle;
+
+  @UI: {
+    lineItem:       [ { position: 40 } ],
+    identification: [ { position: 40 } ]
+  }
+  GoalDescription;
+
+  @UI: {
+    lineItem:       [ { position: 50 } ],
+    identification: [ { position: 50 } ]
+  }
+  CreatedOn;
+}

--- a/src/zc_goal_basic.ddlx.xml
+++ b/src/zc_goal_basic.ddlx.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DDLX" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DDLX>
+    <METADATA>
+     <NAME>ZC_GOAL_BASIC</NAME>
+     <DESCRIPTION>Metadata Extension for Goal Basic View</DESCRIPTION>
+     <MASTER_LANGUAGE>EN</MASTER_LANGUAGE>
+    </METADATA>
+   </DDLX>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zi_goal_basic.ddls.asddls
+++ b/src/zi_goal_basic.ddls.asddls
@@ -1,0 +1,27 @@
+@AbapCatalog.sqlViewName: 'ZIGOALBASIC'
+@AbapCatalog.compiler.compareFilter: true
+@AbapCatalog.preserveKey: true
+@AccessControl.authorizationCheck: #CHECK
+@EndUserText.label: 'Goal Basic Interface View'
+
+define view ZI_GOAL_BASIC
+  as select from zist_goals
+{
+  key goal_id      as GoalId,
+      username     as Username,
+      goal_title   as GoalTitle,
+      goal_desc    as GoalDescription,
+      created_on   as CreatedOn,
+      
+      /* Administrative Data */
+      @Semantics.user.createdBy: true
+      created_by   as CreatedBy,
+      @Semantics.systemDateTime.createdAt: true
+      created_at   as CreatedAt,
+      @Semantics.user.lastChangedBy: true
+      changed_by   as ChangedBy,
+      @Semantics.systemDateTime.lastChangedAt: true
+      changed_at   as ChangedAt,
+      @Semantics.systemDateTime.localInstanceLastChangedAt: true
+      local_last_changed_at as LocalLastChangedAt
+}

--- a/src/zi_goal_basic.ddls.xml
+++ b/src/zi_goal_basic.ddls.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DDLS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DDLS>
+    <DDLNAME>ZI_GOAL_BASIC</DDLNAME>
+    <DDLANGUAGE>E</DDLANGUAGE>
+    <DDTEXT>Goal Basic Interface View</DDTEXT>
+    <SOURCE_TYPE>V</SOURCE_TYPE>
+   </DDLS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
This PR adds the following CDS views for the Goal Service:

1. ZI_GOAL_BASIC - Basic interface view
2. ZC_GOAL_BASIC - Consumption view with UI annotations

Changes include:
- Basic data model with administrative fields
- Search capabilities
- UI annotations for Fiori Elements
- Proper documentation and metadata

These views will serve as the foundation for the RAP implementation of the Goal Service.